### PR TITLE
Show only part of the apikey when running with low verbose

### DIFF
--- a/codetransform/src/main/java/fi/nls/codetransform/Main.java
+++ b/codetransform/src/main/java/fi/nls/codetransform/Main.java
@@ -55,7 +55,12 @@ public class Main {
 
         if (verbosity > 0) {
             System.out.println("Using koodistot base url " + koodistotBaseURL);
-            System.out.println("Using apikey " + apikey);
+            if (verbosity > 3) {
+                System.out.println("Using apikey " + apikey);
+            } else {
+                // just show begin and end
+                System.out.println("Using apikey " + apikey.substring(0,5) + "..." + apikey.substring(apikey.length() - 5));
+            }
         }
 
         KoodistotSuomiFi koodistot = new KoodistotSuomiFi(koodistotBaseURL, apikey, orgId);


### PR DESCRIPTION
So it won't show on the logs for simple debugging.